### PR TITLE
networkx 2 compatbility: add patch from GitHub

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,13 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # Support networkx2, fixed in GitHub but not in a release:
+    # https://github.com/gtaylor/python-colormath/pull/75
+    - networkx2.diff
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/networkx2.diff
+++ b/recipe/networkx2.diff
@@ -1,0 +1,16 @@
+diff --git a/colormath/color_conversions.py b/colormath/color_conversions.py
+index a8d8f36..008d6bd 100644
+--- a/colormath/color_conversions.py
++++ b/colormath/color_conversions.py
+@@ -122,7 +122,10 @@ def get_conversion_path(self, start_type, target_type):
+ 
+     def add_type_conversion(self, start_type, target_type, conversion_function):
+         super(GraphConversionManager, self).add_type_conversion(start_type, target_type, conversion_function)
+-        self.conversion_graph.add_edge(start_type, target_type, {'conversion_function': conversion_function})
++        if networkx.__version__.startswith('2'):
++            self.conversion_graph.add_edge(start_type, target_type, conversion_function=conversion_function)
++        else:
++            self.conversion_graph.add_edge(start_type, target_type, {'conversion_function': conversion_function})
+ 
+ 
+ class DummyConversionManager(ConversionManager):


### PR DESCRIPTION
Adds gtaylor/python-colormath#75 which adds compatibility with networkx
2. This is pulled into colormath GitHub but not available in an official
release.

cc @ewels -- Phil, are you able to review and pull? This fixes MultiQC when networkx >= 2.0 is installed